### PR TITLE
Fix for "** (File.Error) could not read file "VERSION": no such file or directory"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule CubicBezier.MixProject do
     [
       app: :cubic_bezier,
       description: "Elixir implementation of the CSS cubic-bezier function.",
-      version: File.read!("VERSION"),
+      version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
When installing the dependency via mix you would get

```
Error while loading project :cubic_bezier at /app/deps/cubic_bezier
** (File.Error) could not read file "VERSION": no such file or directory
```

Because apparently `VERSION` does not get included when fetching packages via `deps.get`.

So I fixed it.

:wave: 